### PR TITLE
Installability and Compatibility

### DIFF
--- a/bottom.py
+++ b/bottom.py
@@ -1,11 +1,14 @@
-CHARACTER_VALUES = {
-    200: "🫂",
-    50: "💖",
-    10: "✨",
-    5: "🥺",
-    1: ",",
-    0: "❤️"
-}
+from collections import OrderedDict
+
+
+CHARACTER_VALUES = OrderedDict([
+    (200, "🫂"),
+    (50, "💖"),
+    (10, "✨"),
+    (5, "🥺"),
+    (1, ","),
+    (0, "❤️")
+])
 
 SECTION_SEPERATOR = '👉👈'
 
@@ -28,7 +31,8 @@ def to_bottom(text: str) -> str:
 
 def from_bottom(text: str) -> str:
     out = bytearray()
-    text = text.strip().removesuffix(SECTION_SEPERATOR)
+
+    text = text.strip()[:-len(SECTION_SEPERATOR)]
 
     if not all(c in CHARACTER_VALUES.values() for c in text.replace(SECTION_SEPERATOR, '')):
         raise TypeError(f'Invalid bottom text: {text}')

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import pathlib
+
+import setuptools
+
+ROOT = pathlib.Path(__file__).parent
+
+setuptools.setup(
+    name="bottom",
+    version="0.0.1",
+    description="Pure python implementation of https://github.com/bottom-software-foundation/bottom-rs",
+    url="https://github.com/bottom-software-foundation/bottom-py",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[],
+    python_requires=">=3.0",
+)


### PR DESCRIPTION
I added a basic `setup.py` to make the package installable over git and also replaced the `removesuffix` method because it's only available in Python 3.9.
Ordinary dicts are only guaranteed to be ordered in Python 3.6+. Using them could potentially break the encoding for older Python versions.

It's also questionable if this iteration through the whole string is necessary as we could also check the validity in the iteration later:
```py
    if not all(c in CHARACTER_VALUES.values() for c in text.replace(SECTION_SEPERATOR, '')):
        raise TypeError(f'Invalid bottom text: {text}')
```

I also don't see a reason to create a copy of the whole character dict here:
```py
rev_mapping = {v: k for k, v in CHARACTER_VALUES.items()}
```

I didn't want to put these two parts into the Pull Request as I don't know if there are reasons for them.